### PR TITLE
add documentation page

### DIFF
--- a/_data/documentation/01-developer.yml
+++ b/_data/documentation/01-developer.yml
@@ -1,0 +1,8 @@
+title: Developer
+contents:
+
+  - name: OML Specification
+    link: https://opencaesar.github.io/oml-spec/
+
+  - name: Vocabularies
+    link: https://opencaesar.github.io/vocabularies/

--- a/_data/documentation/01-developer.yml
+++ b/_data/documentation/01-developer.yml
@@ -4,5 +4,5 @@ contents:
   - name: OML Specification
     link: https://opencaesar.github.io/oml-spec/
 
-  - name: Vocabularies
+  - name: Vocabulary Specifications
     link: https://opencaesar.github.io/vocabularies/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,6 @@
 # Name should not exceed 20 character
 - name: Documentation
-  link: https://opencaesar.github.io/oml-spec
+  link: /documentation
 - name: Blog
   link: /blog
 - name: Case Studies + Papers


### PR DESCRIPTION
Changed the nav bar link to Documentation to point to a new documentation page.
Added two links in documentation page: one for existing oml spec, and one for vocabularies we just added
