### PR TITLE
remove misplaced backtick

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ cardBodyTwo: "Improve the agility of your practice by employing DevOps technique
 the analysis of your system descriptions using multiple techniques including consistency checking and others."
 
 cardImageThree: valueprop3.png
-cardTitleThree: "Precise change management via provenance metadata`"
+cardTitleThree: "Precise change management via provenance metadata"
 cardBodyThree: "Establish a baseline for your integrated system description, manage change proposals using variant 
 configurations, and calculate impact based on the provenance of the changes."
 


### PR DESCRIPTION
Looks like github editor also added a newline to the end of the file -- I didn't mean to do that, but it's good practice.